### PR TITLE
Fix missing numeric values silently becoming 0 instead of NULL (geonode_5)

### DIFF
--- a/importer_datapackage/handlers/datapackage/mapper.py
+++ b/importer_datapackage/handlers/datapackage/mapper.py
@@ -53,6 +53,20 @@ class TabularDataHelper():
             layer = ET.SubElement(root, "OGRVRTLayer", name=resource.name)
             source = Path(folder, resource.path) if folder else resource.path
             ET.SubElement(layer, "SrcDataSource").text = str(source)
+
+            # Without this, GDAL falls back to matching the VRT layer's own
+            # "name" against the underlying CSV's layer name (its filename
+            # without extension). If a resource's declared name differs from
+            # its CSV file's basename, that lookup silently fails and the
+            # layer imports with zero features - no error anywhere.
+            ET.SubElement(layer, "SrcLayer").text = Path(source).stem
+
+            # Without this, an empty CSV cell for a numeric (Integer/Real) field
+            # is cast to 0 instead of NULL by GDAL's VRT driver, silently turning
+            # missing values into real data. Date/DateTime fields are unaffected.
+            open_options = ET.SubElement(layer, "OpenOptions")
+            ET.SubElement(open_options, "OOI", key="EMPTY_STRING_AS_NULL").text = "YES"
+
             ET.SubElement(layer, "GeometryType").text = "wkbNone"
             ET.SubElement(layer, "LayerSRS").text = "EPSG:4326"
             ET.SubElement(layer, "ExtentXMin").text = "-180"
@@ -65,15 +79,16 @@ class TabularDataHelper():
                 (type, subtype) = _parse_field_type(field)
                 normalized_fieldname = self.fixup_name(field.name)
 
-                ET.SubElement(
-                    layer, "Field", 
-                    src=field.name or "", 
-                    name=normalized_fieldname or "",
-                    # alternativeName=field.title or "", # GDAL >=3.7
-                    # comment=field.description or "", # GDAL >=3.7
-                    type=type,
-                    subtype=subtype,
-                )
+                attrib = {
+                    "src": field.name or "",
+                    "name": normalized_fieldname or "",
+                    # "alternativeName": field.title or "", # GDAL >=3.7
+                    # "comment": field.description or "", # GDAL >=3.7
+                    "type": type,
+                }
+                if subtype:
+                    attrib["subtype"] = subtype
+                ET.SubElement(layer, "Field", **attrib)
 
         # write VRT file
         vrt_filename = Path(folder, filename) if folder else filename
@@ -115,5 +130,5 @@ def _parse_field_type(field) -> tuple:
             # fallback
             type = "String"
 
-    subtype = "None"
+    subtype = None
     return (type, subtype)

--- a/importer_datapackage/handlers/datapackage/tests.py
+++ b/importer_datapackage/handlers/datapackage/tests.py
@@ -1,10 +1,14 @@
+import json
+import shutil
 import uuid
 
 from os import path
+from pathlib import Path
 from mock import MagicMock, patch
 from tempfile import TemporaryDirectory
 
 from frictionless import Package
+from osgeo import ogr
 import xml.etree.cElementTree as ET
 
 from django.test import TestCase
@@ -13,6 +17,7 @@ from geonode.storage.manager import StorageManager
 
 from importer_datapackage.handlers.datapackage.handler import DataPackageFileHandler
 from importer_datapackage.handlers.datapackage.mapper import TabularDataHelper
+from importer_datapackage.handlers.datapackage.util import process_rows
 from importer_datapackage.handlers.datapackage.exceptions import InvalidDataPackageFileException
 
 def _absolute_path(filename: str):
@@ -37,7 +42,7 @@ class TestSchemaToVrtMapper(TestCase):
     def setUpClass(cls) -> None:
         super().setUpClass()
         cls.package = Package(_absolute_path("data/datapackage.json"))
-        cls.mapper = TabularDataHelper(cls.package)
+        cls.mapper = TabularDataHelper(cls.package, DataPackageFileHandler().fixup_name)
 
     def test_write_vrt_file(self):
         with TemporaryDirectory() as tmp_dir:
@@ -100,8 +105,8 @@ class TestHandler(TestCase):
         json_file = files.get("json_file")
         self.assertTrue("datapackage.json" in str(json_file))
 
-    @patch('importer.handlers.common.vector.BaseVectorFileHandler._get_execution_request_object')
-    @patch('importer.orchestrator.ImportOrchestrator.update_execution_request_status')
+    @patch('geonode.upload.handlers.common.vector.BaseVectorFileHandler._get_execution_request_object')
+    @patch('geonode.upload.orchestrator.ImportOrchestrator.update_execution_request_status')
     def test_prepare_import_provides_vrt_file(self, get_exec_request, update):
         valid_zip = _absolute_path("data/valid_data.zip")
         files = _unzip({"zip_file": valid_zip})
@@ -136,3 +141,147 @@ class TestHandler(TestCase):
 
     # TODO Test driver
     # TODO Test create_geonode_resource (subtype)
+
+
+def _write_package(tmp_dir, descriptor, csv_text, csv_name="data.csv"):
+    (Path(tmp_dir) / csv_name).write_text(csv_text)
+    json_path = Path(tmp_dir) / "datapackage.json"
+    json_path.write_text(json.dumps(descriptor))
+    return Package(str(json_path))
+
+
+class TestVrtNullHandling(TestCase):
+    """
+    Regression coverage for a GDAL VRT quirk: casting an empty CSV cell to an
+    Integer/Real VRT field yields 0, not NULL (Date/DateTime are unaffected).
+    See the EMPTY_STRING_AS_NULL OpenOptions in mapper.write_vrt_file.
+
+    The resource name deliberately differs from the CSV filename (a common,
+    valid datapackage pattern) to also guard against a separate GDAL VRT bug:
+    without an explicit SrcLayer, GDAL matches the VRT layer's own "name"
+    against the source CSV's layer name (its filename minus extension), and
+    silently imports zero features when they don't match.
+    """
+
+    _DESCRIPTOR = {
+        "name": "synthetic",
+        "resources": [
+            {
+                "name": "synthetic_data",
+                "path": "data.csv",
+                "format": "csv",
+                "schema": {
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "amount", "type": "number"},
+                        {"name": "label", "type": "string"},
+                        {"name": "measured_on", "type": "date"},
+                    ]
+                },
+            }
+        ],
+    }
+
+    _CSV = "id,amount,label,measured_on\n1,12,foo,2020-01-01\n2,,,\n"
+
+    def test_empty_cells_are_null_not_zero(self):
+        with TemporaryDirectory() as tmp_dir:
+            package = _write_package(tmp_dir, self._DESCRIPTOR, self._CSV)
+            mapper = TabularDataHelper(package, DataPackageFileHandler().fixup_name)
+            vrt_file = mapper.write_vrt_file("test.vrt", tmp_dir)
+
+            datasource = ogr.Open(str(vrt_file))
+            layer = datasource.GetLayer(0)
+            self.assertEqual(layer.GetFeatureCount(), 2)
+
+            populated = layer.GetNextFeature()
+            self.assertTrue(populated.IsFieldSetAndNotNull("id"))
+            self.assertTrue(populated.IsFieldSetAndNotNull("amount"))
+            self.assertTrue(populated.IsFieldSetAndNotNull("label"))
+            self.assertTrue(populated.IsFieldSetAndNotNull("measured_on"))
+            self.assertEqual(populated.GetField("amount"), 12.0)
+
+            blank = layer.GetNextFeature()
+            self.assertTrue(blank.IsFieldSetAndNotNull("id"))
+            self.assertFalse(blank.IsFieldSetAndNotNull("amount"))
+            self.assertFalse(blank.IsFieldSetAndNotNull("label"))
+            self.assertFalse(blank.IsFieldSetAndNotNull("measured_on"))
+
+
+class TestProcessRowsMissingValues(TestCase):
+    """
+    Locks in that util.process_rows() (the frictionless normalization step)
+    already correctly empties a cell whose value matches a field's declared
+    missingValues, for every field type - and leaves an undeclared sentinel
+    (same literal text, no missingValues on that field) untouched.
+    """
+
+    _DESCRIPTOR = {
+        "name": "synthetic",
+        "resources": [
+            {
+                "name": "data",
+                "path": "data.csv",
+                "format": "csv",
+                "schema": {
+                    "fields": [
+                        {"name": "id", "type": "integer"},
+                        {"name": "amount", "type": "number", "missingValues": ["NA"]},
+                        {"name": "measured_on", "type": "date", "missingValues": ["NA"]},
+                        {"name": "note", "type": "string"},
+                    ]
+                },
+            }
+        ],
+    }
+
+    _CSV = "id,amount,measured_on,note\n1,12.5,2020-01-01,foo\n2,NA,NA,NA\n"
+
+    def test_declared_missing_values_become_empty_cells(self):
+        with TemporaryDirectory() as tmp_dir:
+            package = _write_package(tmp_dir, self._DESCRIPTOR, self._CSV)
+            process_rows(package.get_resource("data"))
+
+            rows = (Path(tmp_dir) / "data.csv").read_text().strip().splitlines()
+            self.assertEqual(rows[0], "id,amount,measured_on,note")
+            self.assertEqual(rows[1], "1,12.5,2020-01-01,foo")
+            # amount/measured_on declare missingValues -> emptied out;
+            # note has no missingValues declared -> literal "NA" survives untouched
+            self.assertEqual(rows[2], "2,,,NA")
+
+
+class TestDataPackageEndToEndNullHandling(TestCase):
+    """
+    Combines process_rows() + write_vrt_file() exactly as prepare_import() does,
+    against the bundled real-world fixture (laboratory_data.BD_bulk is a number
+    field with missingValues=["NA"]), proving a declared missing value round-trips
+    to a true NULL in the generated VRT layer rather than silently becoming 0.
+    """
+
+    def test_missing_number_value_is_null_in_vrt(self):
+        with TemporaryDirectory() as tmp_dir:
+            for fname in ("datapackage.json", "HORIZON_DATA.csv", "LABORATORY_DATA.csv"):
+                shutil.copy(_absolute_path(f"data/{fname}"), path.join(tmp_dir, fname))
+
+            package = Package(path.join(tmp_dir, "datapackage.json"))
+            resource = package.get_resource("laboratory_data")
+            process_rows(resource)
+
+            mapper = TabularDataHelper(package, DataPackageFileHandler().fixup_name)
+            vrt_file = mapper.write_vrt_file("test.vrt", tmp_dir)
+
+            datasource = ogr.Open(str(vrt_file))
+            layer = datasource.GetLayerByName("laboratory_data")
+
+            null_count = 0
+            set_count = 0
+            layer.ResetReading()
+            for feature in layer:
+                if feature.IsFieldSetAndNotNull("bd_bulk"):
+                    set_count += 1
+                    self.assertNotEqual(feature.GetField("bd_bulk"), 0.0)
+                else:
+                    null_count += 1
+
+            self.assertGreater(null_count, 0, "expected at least one NULL BD_bulk row (missingValues)")
+            self.assertGreater(set_count, 0, "expected at least one populated BD_bulk row")


### PR DESCRIPTION
## Summary

Ports the fix from #33 (merged into `main`) onto `geonode_5`, which had independently diverged (ported to the native `geonode.upload` core) and could not be cleanly merged/cherry-picked — verified with `git merge-tree`, which produces real conflicts in both `mapper.py` and `util.py`.

Fixes #32 on this branch too. Two bugs in `TabularDataHelper.write_vrt_file()`, both silently corrupting/losing data during import with no error surfaced anywhere:

1. **Missing values become `0`, not `NULL`, for `integer`/`number` columns.** Fixed the same way as on `main`: added `<OpenOptions><OOI key="EMPTY_STRING_AS_NULL">YES</OOI></OpenOptions>` to each `<OGRVRTLayer>`.
2. **Resources import with zero rows when the resource `name` differs from its CSV filename.** `write_vrt_file()` never set `<SrcLayer>`, so GDAL fell back to matching the VRT layer's `name` against the source CSV's own layer name (its filename minus extension) — silently zero features when they don't match. Fixed by explicitly setting `<SrcLayer>` to the CSV's basename.

### What's different from the `main` PR

- `geonode_5`'s `write_vrt_file()` already has its own independent additions (`<GeometryType>`, `<LayerSRS>`, world-bounds extents) — left untouched, the two fixes are inserted around them.
- **`util.py` is intentionally NOT touched here.** On `main`, the decimal-comma conversion step was dead code and was removed. On `geonode_5`, that same step has already been activated/fixed (`*to_point_decimal_steps` is live with a working implementation) — it's unrelated to the VRT null-handling bugs, and porting the `main` diff would have deleted working code.
- Also fixed, left over from the `geonode.upload` port and unrelated to the null-value bug but touched in the same file: `TestSchemaToVrtMapper.setUpClass` was still calling `TabularDataHelper(cls.package)` missing the required `fixup_name` arg (`TypeError`), and `test_prepare_import_provides_vrt_file`'s `@patch(...)` decorators still pointed at the old `importer.orchestrator`/`importer.handlers.common.vector` module paths instead of `geonode.upload.orchestrator`/`geonode.upload.handlers.common.vector`.

## Test plan

- [x] Verified the ported `mapper.py` directly against GDAL (no Django/`geonode.upload` dependency needed for this module) inside a GDAL 3.4.1 environment: a resource whose `name` differs from its CSV filename now returns the correct feature count (was 0 before), and empty numeric/date/string cells report `IsFieldSetAndNotNull() == False` (were `0`/`0.0` for numeric fields before).
- [x] Verified end-to-end against the bundled real-world fixture's `BD_bulk` column (declared `missingValues: ["NA"]`): 21 features total, exactly 1 correctly NULL, 20 correctly populated, none silently `0.0`.
- [ ] Full Django test suite (including the ported `TestVrtNullHandling`, `TestProcessRowsMissingValues`, `TestDataPackageEndToEndNullHandling`) needs a `geonode_5`-compatible (`geonode.upload`) environment to run, which wasn't available in this session — please run in CI/a GeoNode 5 environment before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)